### PR TITLE
Add --insecure option for SSL certificate verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,44 @@ build
 _work
 /.cache
 /.tox
+CLAUDE.md
+
+# Virtual environments
+venv/
+env/
+ENV/
+env.bak/
+venv.bak/
+
+# Python distribution / packaging
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Python bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Testing
+.coverage
+htmlcov/
+.pytest_cache/
+.hypothesis/
+.coverage.*
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/idstools/scripts/rulecat.py
+++ b/idstools/scripts/rulecat.py
@@ -263,7 +263,7 @@ class Fetch(object):
                 open(tmp_filename, "rb").read()).hexdigest().strip()
             remote_checksum_buf = io.BytesIO()
             logger.info("Checking %s." % (checksum_url))
-            idstools.net.get(checksum_url, remote_checksum_buf)
+            idstools.net.get(checksum_url, remote_checksum_buf, insecure=self.args.insecure)
             remote_checksum = remote_checksum_buf.getvalue().decode().strip()
             logger.debug("Local checksum=|%s|; remote checksum=|%s|" % (
                 local_checksum, remote_checksum))
@@ -317,7 +317,8 @@ class Fetch(object):
         idstools.net.get(
             url,
             open(tmp_filename, "wb"),
-            progress_hook=self.progress_hook if not self.args.quiet else None)
+            progress_hook=self.progress_hook if not self.args.quiet else None,
+            insecure=self.args.insecure)
         if not self.args.quiet:
             self.progress_hook_finish()
         logger.info("Done.")
@@ -773,6 +774,8 @@ def main():
                         help="Command to test Suricata configuration")
     parser.add_argument("-V", "--version", action="store_true", default=False,
                         help="Display version")
+    parser.add_argument("--insecure", action="store_true", default=False,
+                        help="Skip SSL verification (INSECURE)")
 
     args = parser.parse_args()
 
@@ -788,6 +791,9 @@ def main():
     logger.debug("This is idstools-rulecat version %s; Python: %s" % (
         idstools.version,
         sys.version.replace("\n", "- ")))
+        
+    if args.insecure:
+        logger.warning("SSL verification disabled. This is INSECURE!")
 
     if args.dump_sample_configs:
         return dump_sample_configs()

--- a/tests/test_rulecat.py
+++ b/tests/test_rulecat.py
@@ -111,7 +111,12 @@ class TestFetch(unittest.TestCase):
         """Test that we detect when the checksum are the same. This is mainly
         to catch issues between Python 2 and 3.
         """
-        fetch = rulecat.Fetch(None)
+        # Create a mock args object with insecure set to False
+        class MockArgs:
+            def __init__(self):
+                self.insecure = False
+        
+        fetch = rulecat.Fetch(MockArgs())
         url = "file://%s/emerging.rules.tar.gz" % (
             os.path.dirname(os.path.realpath(__file__)))
         local_file = "%s/emerging.rules.tar.gz" % (


### PR DESCRIPTION
- Add insecure parameter to net.get() function to skip SSL verification
- Add --insecure command-line option to rulecat with warning message
- Update tests to support the new parameter
- Expand .gitignore with common Python development patterns